### PR TITLE
rename to choop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">rooch</h1>
+<h1 align="center">choop</h1>
 
 <div align="center">
   🚂🚋🚋🚋🚋🚋 + ⚛
@@ -19,13 +19,13 @@
       alt="API stability" />
   </a>
   <!-- NPM version -->
-  <a href="https://npmjs.org/package/rooch">
-    <img src="https://img.shields.io/npm/v/rooch.svg?style=flat-square"
+  <a href="https://npmjs.org/package/choop">
+    <img src="https://img.shields.io/npm/v/choop.svg?style=flat-square"
       alt="NPM version" />
   </a>
   <!-- Downloads -->
-  <a href="https://npmjs.org/package/rooch">
-    <img src="https://img.shields.io/npm/dm/rooch.svg?style=flat-square"
+  <a href="https://npmjs.org/package/choop">
+    <img src="https://img.shields.io/npm/dm/choop.svg?style=flat-square"
       alt="Downloads" />
   </a>
   <!-- Standard -->
@@ -37,7 +37,7 @@
 
 <br/>
 
-Ever wondered what would happen if `react` and [choo](https://github.com/yoshuawuyts/choo) got a baby?
+Ever wondered what would happen if `(p)react` and [choo](https://github.com/yoshuawuyts/choo) got a baby?
 
 Welp, wonder no longer - here's the answer. Full on [choo](https://github.com/yoshuawuyts/choo) architecture plus a couple `preact` goodies like [`h()`](https://preactjs.com/guide/differences-to-react#what-s-included-) and [components](https://preactjs.com/guide/lifecycle-methods). No JSX, only template strings via [hyperx](https://github.com/substack/hyperx). But you can use JSX if you want to. We even support almost all of the React ecosystem through [preact-compat](https://github.com/developit/preact-compat).
 
@@ -46,11 +46,11 @@ Welp, wonder no longer - here's the answer. Full on [choo](https://github.com/yo
 Why is this useful? Sometimes you gotta use `react`, and the best thing to do in that case is to jump on the `preact` train, grab a bag of architecture and go to town. This might not be for me, but perhaps it's useful for you. Here you go! 🎁
 
 ```js
-var html = require('rooch/html')
+var html = require('choop/html')
 var devtools = require('choo-devtools')
-var rooch = require('rooch')
+var choop = require('choop')
 
-var app = rooch()
+var app = choop()
 app.use(devtools())
 app.use(countStore)
 app.route('/', mainView)
@@ -84,11 +84,11 @@ Only difference is `preact` will append our app to the element passed into `moun
 
 ## Components
 
-You can create stateful components right out of the box with `rooch`:
+You can create stateful components right out of the box with `choop`:
 
 ```js
-var Component = require('rooch/component')
-var html = require('rooch/html')
+var Component = require('choop/component')
+var html = require('choop/html')
 
 class ClickMe extends Component {
   constructor () {
@@ -112,8 +112,8 @@ class ClickMe extends Component {
 And then render them in your views using `h()`:
 
 ```js
-var html = require('rooch/html')
-var h = require('rooch/h')
+var html = require('choop/html')
+var h = require('choop/h')
 
 var ClickMe = require('./ClickMe')
 
@@ -138,7 +138,7 @@ You can use `props` or an additional constructor function to pass `emit` into yo
 ### Should I use this?
 Maybe? If you've got no choice other than using `(p)react` this might be useful.
 
-### How do I run react widgets in rooch?
+### How do I run react widgets in choop?
 Like [this](https://github.com/preact-compat/react):
 
 ```
@@ -155,5 +155,5 @@ Yeah, what about me? (_drumroll_)
 
 ## Installation
 ```sh
-$ npm install rooch
+$ npm install choop
 ```

--- a/example/component.js
+++ b/example/component.js
@@ -1,4 +1,4 @@
-var rooch = require('..')
+var choop = require('..')
 var html = require('../html')
 var h = require('../h')
 var Component = require('../component')
@@ -29,7 +29,7 @@ function view (state, emit) {
   `
 }
 
-var app = rooch()
+var app = choop()
 
 app.route('/', view)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rooch",
+  "name": "choop",
   "version": "3.0.0",
   "description": "Choo x Preact",
   "main": "index.js",
@@ -11,7 +11,7 @@
     "start": "bankai start example",
     "test": "standard && npm run deps && node test.js"
   },
-  "repository": "yoshuawuyts/rooch",
+  "repository": "choojs/choop",
   "keywords": [
     "choo",
     "preact",


### PR DESCRIPTION
`rooch` has basically just become `choo` but with `preact` instead of `nanomorph`. So, with this tighter connection to `preact`, and a goal to keep it more actively maintained, is something like `choop` a better name? If we were to rename it, do we want to start at `1.0.0` or just continue on with `rooch` versioning at `3.0.0`? This PR handles the name swap in case it's something we like.

